### PR TITLE
Quito el timeout de las ejecuciones de procesos

### DIFF
--- a/src/Console/Command/Docker/Compose/Down.php
+++ b/src/Console/Command/Docker/Compose/Down.php
@@ -43,7 +43,7 @@ class Down extends Command
             $output->writeln("<info>Deteniendo contenedores</info>");
             $cwdParts = explode( '/', getenv('CWD'));
             $cwd = end($cwdParts);
-            $result = $this->exec->run(["docker-compose", "down"], "/app/compose/{$cwd}", null, null, 60, true);
+            $result = $this->exec->run(["docker-compose", "down"], "/app/compose/{$cwd}", null, null, null, true);
             $output->writeln($result);
 
             return Command::SUCCESS;

--- a/src/Console/Command/Docker/Compose/Logs.php
+++ b/src/Console/Command/Docker/Compose/Logs.php
@@ -43,7 +43,7 @@ class Logs extends Command
             $output->writeln("<info>Preparando logs...</info>");
             $cwdParts = explode( '/', getenv('CWD'));
             $cwd = end($cwdParts);
-            $result = $this->exec->run(["docker-compose", "logs", "-f"], "/app/compose/{$cwd}", null, null, 60, true);
+            $result = $this->exec->run(["docker-compose", "logs", "-f"], "/app/compose/{$cwd}", null, null, null, true);
             $output->writeln($result);
 
             return Command::SUCCESS;

--- a/src/Console/Command/Docker/Compose/Up.php
+++ b/src/Console/Command/Docker/Compose/Up.php
@@ -43,7 +43,7 @@ class Up extends Command
             $output->writeln("<info>Iniciando contenedores</info>");
             $cwdParts = explode( '/', getenv('CWD'));
             $cwd = end($cwdParts);
-            $result = $this->exec->run(["docker-compose", "up", "-d"], "/app/compose/{$cwd}", null, null, 60, true);
+            $result = $this->exec->run(["docker-compose", "up", "-d"], "/app/compose/{$cwd}", null, null, null, true);
             $output->writeln($result);
 
             return Command::SUCCESS;

--- a/src/Console/Command/Update.php
+++ b/src/Console/Command/Update.php
@@ -40,7 +40,7 @@ class Update extends Command
     {
         try {
             $output->writeln("<info>Actualizando aplicación</info>");
-            $result = $this->exec->run(["docker", "pull", "dgutman/lyradock"], null, null, null, 60, true);
+            $result = $this->exec->run(["docker", "pull", "dgutman/lyradock"], null, null, null, null, true);
             $output->writeln($result);
 
             return Command::SUCCESS;


### PR DESCRIPTION
El timeout estaba cortando los procesos como up en caso de que se tengan que descargar las imagenes de docker por primera vez